### PR TITLE
move c header back to astal-tray.h

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -2,7 +2,6 @@ version_split = meson.project_version().split('.')
 api_version = version_split[0] + '.' + version_split[1]
 gir = 'AstalTray-' + api_version + '.gir'
 typelib = 'AstalTray-' + api_version + '.typelib'
-so = 'lib' + meson.project_name() + '.so.' + meson.project_version()
 
 config = configure_file(
   input: 'config.vala.in',
@@ -59,7 +58,7 @@ if get_option('lib')
     c_args: dbusmenu_cflags.split(' '),
     link_args: dbusmenu_libs.split(' '),
     install: true,
-    install_dir: [true, get_option('includedir') / 'astal', true, true],
+    install_dir: [true, true, true, true],
   )
 
   import('pkgconfig').generate(

--- a/src/meson.build
+++ b/src/meson.build
@@ -50,7 +50,7 @@ if get_option('lib')
     meson.project_name(),
     sources,
     dependencies: deps,
-    vala_header: meson.project_name().replace('astal-', '') + '.h',
+    vala_header: meson.project_name() + '.h',
     vala_vapi: meson.project_name() + '-' + api_version + '.vapi',
     vala_gir: gir,
     vala_args: ['--pkg', 'DbusmenuGtk3-0.4', '--pkg', 'Dbusmenu-0.4'],


### PR DESCRIPTION
as discussed before, placing the header to astal/tray.h breaks it when using it from another vala project